### PR TITLE
G2 updates collab

### DIFF
--- a/app/discover/page.tsx
+++ b/app/discover/page.tsx
@@ -1,19 +1,38 @@
-import React from 'react';
+import { livepeer } from '@app/lib/sdk/livepeer/client';
 import {
+  Box,
+  Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
-  Breadcrumb,
-  Box,
-  Heading,
   Flex,
+  Heading,
   Text,
 } from '@chakra-ui/react';
-import { livepeer } from '@app/lib/sdk/livepeer/client';
-import Link from 'next/link';
-import VideoCardGrid from '@app/ui/components/Videos/VideoCardGrid';
 
-const AllVideosPage = () => {
-  const allAssets = livepeer?.asset.getAll();
+const AllVideosPage = async () => {
+  try {
+
+    /**
+     * @dev
+     * The data isn't populating because it fails to pass some `Zod` validation
+     * that the sdk is using internally (probably to checkmate the `types` taht makes 
+     * up the `Assert` object)
+     */
+    const { data, error } = await livepeer.asset.getAll();
+
+    console.log('data101: ', data);
+  } catch (err: any) {
+    /**
+     * @dev
+     * The `Assert` observed at the console is a selected few that the 
+     * sdk added to the `error` object inside a `rawValue` field
+     * 
+     * @note If only the `error` object is accessed; one would see the
+     * entire `zod` validation error
+     */
+    console.log('error101: ', err.rawValue);
+  }
+
   return (
     <main>
       <Box my={10} p={4}>
@@ -35,7 +54,7 @@ const AllVideosPage = () => {
         <Heading mb={10}>Discover Content</Heading>
         <Flex flexDirection="column" my={10} gap={5} maxW="md">
           <Text>This is the Discover page.</Text>
-          {JSON.stringify(allAssets)}
+          {/* {JSON.stringify(allAssets)} */}
           {/* <VideoCardGrid  />  */}
         </Flex>
       </Box>


### PR DESCRIPTION
While it was successful to fetch an Assert by its id; attempt to fetch all asserts at a time errored out. Reasons for such error was commented within the affected codebase and am thinking a possible solution (or where to start) would be:

1. To `delete` the current asserts via api call (as it's all demo file); and create new ones, firstly from within the Livepeer's dashboard. If all goes well, then we attempt to create assert from the clients (user) side.
2. If same error with new Asserts; then a support ticket on the SDK be submitted to Livepeer